### PR TITLE
feat(profile): add profile management with preferences support and JW…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   pollVotes   PollVote[]
   polls       Poll[]
   password    String?
+  preferences Json?
 
   @@map("users")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { CommentsModule } from './comments/comments.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { RedisModule } from './redis/redis.module';
 import { AuthModule } from './auth/auth.module';
+import { ProfileModule } from './profile/profile.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { AuthModule } from './auth/auth.module';
     RedisModule,
     CommentsModule,
     AuthModule,
+    ProfileModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,17 +1,20 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { JwtStrategy } from './strategies/jwt.strategy';
 import { PrismaService } from '../prisma/prisma.service';
-import { JwtModule } from '@nestjs/jwt';
 
 @Module({
   imports: [
+    PassportModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET,
       signOptions: { expiresIn: '1h' },
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, PrismaService],
+  providers: [AuthService, PrismaService, JwtStrategy],
 })
 export class AuthModule {}

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_SECRET,
+    });
+  }
+
+  async validate(payload: { sub: string; email: string }) {
+    return { sub: payload.sub, email: payload.email };
+  }
+}

--- a/src/profile/dto/change-password.dto.ts
+++ b/src/profile/dto/change-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @IsString() currentPassword: string;
+  @IsString() @MinLength(6) newPassword: string;
+}

--- a/src/profile/dto/update-profile.dto.ts
+++ b/src/profile/dto/update-profile.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsObject } from 'class-validator';
+
+export class UpdateProfileDto {
+  @ApiProperty({ description: 'Display name of the user', example: 'John Doe', required: false })
+  @IsOptional()
+  @IsString()
+  displayName?: string;
+
+  @ApiProperty({ description: 'User bio', example: 'Full-stack developer', required: false })
+  @IsOptional()
+  @IsString()
+  bio?: string;
+
+  @ApiProperty({ description: 'Avatar URL', example: 'https://example.com/avatar.jpg', required: false })
+  @IsOptional()
+  @IsString()
+  avatarUrl?: string;
+
+  @ApiProperty({
+    description: 'User preferences in JSON format',
+    example: { theme: 'dark', language: 'en', notifications: true },
+    required: false
+  })
+  @IsOptional()
+  @IsObject()
+  preferences?: Record<string, any>;
+}

--- a/src/profile/profile.controller.spec.ts
+++ b/src/profile/profile.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProfileController } from './profile.controller';
+
+describe('ProfileController', () => {
+  let controller: ProfileController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProfileController],
+    }).compile();
+
+    controller = module.get<ProfileController>(ProfileController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Put, Body, UseGuards, Request } from '@nestjs/common';
+import { ProfileService } from './profile.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('profile')
+@UseGuards(JwtAuthGuard)
+export class ProfileController {
+  constructor(private profileService: ProfileService) {}
+
+  @Put('update')
+  updateProfile(@Request() req, @Body() dto: UpdateProfileDto) {
+    return this.profileService.updateProfile(req.user.sub, dto);
+  }
+
+  @Put('change-password')
+  changePassword(@Request() req, @Body() dto: ChangePasswordDto) {
+    return this.profileService.changePassword(req.user.sub, dto.currentPassword, dto.newPassword);
+  }
+}

--- a/src/profile/profile.module.ts
+++ b/src/profile/profile.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+
+@Module({
+  controllers: [ProfileController],
+  providers: [ProfileService]
+})
+export class ProfileModule {}

--- a/src/profile/profile.service.spec.ts
+++ b/src/profile/profile.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProfileService } from './profile.service';
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProfileService],
+    }).compile();
+
+    service = module.get<ProfileService>(ProfileService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import * as bcrypt from 'bcrypt';   
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+@Injectable()
+export class ProfileService {
+  constructor(private prisma: PrismaService) {}
+
+  async updateProfile(userId: string, dto: UpdateProfileDto) {
+  return this.prisma.user.update({
+    where: { id: userId },
+    data: {
+      displayName: dto.displayName,
+      bio: dto.bio,
+      avatarUrl: dto.avatarUrl,
+      preferences: dto.preferences
+    }
+  });
+}
+
+
+  async changePassword(userId: string, currentPassword: string, newPassword: string) {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new BadRequestException('User not found');
+
+    const isValid = await bcrypt.compare(currentPassword, user.password);
+    if (!isValid) throw new BadRequestException('Current password is incorrect');
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { password: hashed },
+    });
+    return { message: 'Password updated successfully' };
+  }
+}


### PR DESCRIPTION
- Added `preferences` JSON field to `User` model in Prisma schema
- Implemented `UpdateProfileDto` with Swagger decorators
- Updated profile service to allow updating displayName, bio, avatarUrl, and preferences
- Added `JwtAuthGuard` to secure profile update endpoint
- Updated API documentation in Swagger for new profile fields